### PR TITLE
python setup.py test (and consequences)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 *.c
 *.pyc
+*.so
 build/
 out/
 messages/*.proto

--- a/README.md
+++ b/README.md
@@ -40,11 +40,19 @@ Fork and clone the repository, then run:
 It will generate the platform specific pyrobuf_list them compile
 the pyrobuf_list and pyrobuf_util modules.
 
-You can then run the test suite (a work in progress) using py.test:
+You can then run the test suite (a work in progress) using py.test directly:
 
     $ PYTHONPATH=build/lib.<platform>-<python version> py.test
 
-`test_gen_message` will attempt to process all the proto files in
+Or using the `test` command (which installs pytest if not already available):
+
+    $ python setup.py test
+
+The `clean` command does the house keeping for you:
+
+    $ python setup.py clean
+
+`test__gen_message` will attempt to process all the proto files in
 `tests/proto`.
 
 If you find that pyrobuf does not work for one of your proto files, add a minimal


### PR DESCRIPTION
- remove generate_list setup command
- add test setup command
- document test and clean command
- add *.so to gitignore because test puts pyrobuf_list and pyrobuf_util at the root of the repo
- modify clean to delete the .so generated by test
